### PR TITLE
Add support for Catberry 9.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ notifications:
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "5"
+  - "6"
+  - "7"

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -94,16 +94,21 @@ class Logger extends LoggerBase {
 		eventBus
 			.on('storeFound', args => this.info(`Store "${args.name}" found at ${args.path}`))
 			.on('componentFound', args => this.info(`Component "${args.name}" found at ${args.path}`))
-			.on('bootsrapperBuilt', args => {
+			.on('appDefinitionsBuilt', args => {
 				const timeMessage = prettyHrTime(args.hrTime);
-				this.info(`Bootstrapper has been built (${timeMessage})`);
+				this.info(`App definitions have been built (${timeMessage})`);
 			})
-			.on('bundleBuilt', args => {
+			.on('appBundleBuilt', args => {
 				const timeMessage = prettyHrTime(args.hrTime);
-				this.info(`Browser bundle has been built at ${args.path} (${timeMessage})`);
+				this.info(`Browser app bundle has been built at ${args.path} (${timeMessage})`);
 			})
-			.on('bundleChanged', args => {
-				this.info(`Bundle has been updated, changed files: [${args.changedFiles.join(',')}]`);
+			.on('externalsBundleBuilt', args => {
+				const timeMessage = prettyHrTime(args.hrTime);
+				this.info(`Browser externals bundle has been built at ${args.path} (${timeMessage})`);
+			})
+
+			.on('appBundleChanged', args => {
+				this.info(`App bundle has been updated, changed files: [${args.changedFiles.join(',')}]`);
 			});
 	}
 

--- a/package.json
+++ b/package.json
@@ -24,14 +24,18 @@
 		"./lib/Logger.js": "./browser/Logger.js"
 	},
 	"dependencies": {
-		"pretty-hrtime": "^1.0.2",
-		"chalk": "^1.1.1"
+		"pretty-hrtime": "^1.0.3",
+		"chalk": "^1.1.3"
 	},
 	"devDependencies": {
-		"eslint": "^2.0.0"
+		"eslint": "^3.18.0"
 	},
+	"peerDependencies": {
+		"catberry": "^9.0.0"
+	},
+
 	"engines": {
-		"node": ">=4"
+		"node": ">=6.10"
 	},
 	"scripts": {
 		"test": "./node_modules/.bin/eslint ./",


### PR DESCRIPTION
There were some breaking changes in event names:

* `bundleBuilt` => `appBundleBuild`
* `bundleChanged` => `appBundleChanged`
* `bootstrapperBuild` => `appDefinitionsBuilt`
* added `externalsBundleBuild` event